### PR TITLE
feedback: RFC on changes

### DIFF
--- a/aws/existing-vpc/README.md
+++ b/aws/existing-vpc/README.md
@@ -1,21 +1,24 @@
 # Create a DC/OS Cluster using an existing VPC
-In this example we will create an DC/OS cluster using an already existing VPC. The `main.tf` file in this repository is our example implementation using the default VPC which is predefined in any account.
+In this example, we will create a DC/OS cluster using an already existing VPC. The `main.tf` file in this repository is our example implementation using the default VPC which is predefined in an account.
 
-## Requiered Variables
+## Required Variables
 - `admin_ips` List of CIDR addresses who get access to the cluster.
 - `ssh_public_key` SSH public key to be used for deploying the cluster.
+
+## Infrastructure Assumptions
+- A default VPC within a given region
+- You have at LEAST 1 subnet within that VPC
 
 ## Suggested commands
 
 ```bash
 $ terraform init
 $ terraform plan -var "admin_ips=[\"$(curl http://whatismyip.akamai.com)/32\"]" -var "ssh_public_key=\"$(cat ~/.ssh/id_rsa.pub)\"" -out cluster.plan
-$ terraform apply "cluster.plan"
+$ AWS_DEFAULT_REGION=<region> terraform apply "cluster.plan"
 ```
 
 ## Local Variables
 We've added intermediate local variables for all module output and inputs. This will make it easy replacing parts of the modules with your own code.
-
 
 ### Example
 In this example you see the local variable `elb_masters_dns_name` is used as in input in the end instead of directly mentioning `module.dcos-elb.masters_dns_name` the benefit of this is you can replace this variable with a static string or with a completely different output. E.g. a data resources of an already existing load balancer.
@@ -42,4 +45,3 @@ output "elb.masters_dns_name" {
   description = "This is the load balancer address to access the DC/OS UI"
   value       = "${local.elb_masters_dns_name}"
 }
-```

--- a/aws/existing-vpc/external-existing-vpc-example/README.md
+++ b/aws/existing-vpc/external-existing-vpc-example/README.md
@@ -1,0 +1,24 @@
+# External Existing VPC Resource Example
+
+This terraform script shows what the minimum requirments are to ensure that this top level terraform example will works if there is no default VPC in your region and if there exist one but doesn't fulfill the requirements listed in the top-level README.md.
+
+## Deploy
+
+  ```bash
+  terraform apply
+  ```
+
+## Configure
+
+Once when the VPC is deployed, head over to the top level module and provide the output of the `vpc_id` as a variable input to the example.
+
+  ```bash
+  # top-level terraform module
+  terraform apply -var vpc_id="vpc-xxxxxxxxxxxxxxxx" ...
+  ```
+
+## Destroy 
+
+  ```bash
+  terraform destroy
+  ```

--- a/aws/existing-vpc/external-existing-vpc-example/main.tf
+++ b/aws/existing-vpc/external-existing-vpc-example/main.tf
@@ -1,0 +1,28 @@
+# Create a VPC to launch our instances into
+resource "aws_vpc" "default" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = "true"
+}
+
+# Create a subnet to launch public nodes into
+resource "aws_subnet" "public" {
+  vpc_id                  = "${aws_vpc.default.id}"
+  cidr_block              = "10.0.0.0/22"
+  map_public_ip_on_launch = true
+}
+
+# Create an internet gateway to give our subnet access to the outside world
+resource "aws_internet_gateway" "default" {
+  vpc_id = "${aws_vpc.default.id}"
+}
+
+# Grant the VPC internet access on its main route table
+resource "aws_route" "internet_access" {
+  route_table_id         = "${aws_vpc.default.main_route_table_id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${aws_internet_gateway.default.id}"
+}
+
+output "vpc_id" {
+  value = "${aws_vpc.default.id}"
+}


### PR DESCRIPTION
# Feedback / Issues Discovered

With this PR it resolves a few things:
 * content in README.md for customer assumptions/requirements and typos
 * funtional issues with main.tf

There here are the changes needed with the example. Here they are listed below:
I have taken a look at the examples from both the README.md content along with testing the main.tf functionally and provided some revisions to this.


## Assumptions required for VPC
There are a couple of assumptions are made with this example. In order for a customer to have success with using this, we must list out the assumptions when using an external VPC so they are on the same page. Here they are below listed below. You must have at least:
 * A default VPC within a given region
 * You have at LEAST 1 subnet within that VPC
 * An internet gateway must be associated with the VPC for internet traffic to where the Universal Installer is run.
 
## Subnet errors if not provided in VPC 
Error: Error refreshing state: 1 error(s) occurred:

```
* data.aws_subnet_ids.default_subnets: 1 error(s) occurred:

* data.aws_subnet_ids.default_subnets: data.aws_subnet_ids.default_subnets: no matching subnet found for vpc with id vpc-00d48aa88b1a91c00
```


## Terraform plan method is buggy and requires AWS_DEFAULT_REGION

Our instructions need to call out the need for AWS_DEFAULT_REGION. We will need to be explicit about this in our docs if we plan for customers to use the terraform plan. If we are not required, we can also remove the `plan` method and call apply directly to avoid failures. Here is what the error looks like below:

```
terraform apply "cluster.plan"

Error: Error applying plan:

1 error(s) occurred:

* provider.aws: Invalid AWS Region:

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

### WORKAROUND

Here is the workaround in order for this to work properly. We can take it or leave it with simple `terraform apply` and the customers can choose what they want.

```bash
AWS_DEFAULT_REGION=us-west-2 terraform apply "cluster.plan"
```

## VPC Requires an internet gateway to work with Universal Installer

If a VPC exist because the customer created it but the simply forgot to add an internet gateway, they will encounter this error as I did and will need to add this manually to the VPC. We just need to call out this assumption in our docs.

```bash
* aws_elb.loadbalancer: InvalidSubnet: VPC vpc-0fed45a91cdeb5ff1 has no internet gateway
        status code: 400, request id: 1818dc4d-3c60-11e9-b5a4-6ff5ab60e810
* module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[0]: interrupted - last error: dial tcp 54.203.53.154:22: i/o timeout
* module.dcos-privateagent-instances.module.dcos-private-agent-instances.null_resource.instance-prereq[1]: interrupted - last error: dial tcp 54.190.150.125:22: i/o timeout
* module.dcos-publicagent-instances.module.dcos-public-agent-instances.null_resource.instance-prereq: interrupted - last error: dial tcp 54.185.161.214:22: i/o timeout
* module.dcos-privateagent-instances.module.dcos-private-agent-instances.null_resource.instance-prereq[0]: interrupted - last error: dial tcp 54.244.82.160:22: i/o timeout
* module.dcos-bootstrap-instance.module.dcos-bootstrap-instance.null_resource.instance-prereq: interrupted - last error: dial tcp 18.236.63.5:22: i/o timeout
* module.dcos-install.module.dcos-bootstrap-install.null_resource.bootstrap: interrupted - last error: dial tcp 18.236.63.5:22: i/o timeout
* module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[2]: interrupted - last error: dial tcp 54.188.212.175:22: i/o timeout
```

## Dependency is not configured in the example

The dependency is broken when testing out the deployment of the main.tf provided. It attempts to install prereqs and trigger the bootstrap process simultaneously as docker has not gotten the chance to install it. The solution was updated in the main.tf to add the `prereq-id` in order for this to function properly and create a working cluster in the end.

```
module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[1] (remote-exec): Complete!
module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[1] (remote-exec): + sudo systemctl enable ntpd
module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[1] (remote-exec): Created symlink from /etc/systemd/system/multi-user.target.wants/ntpd.service to /usr/lib/systemd/system/ntpd.service.
module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[1] (remote-exec): + sudo systemctl start ntpd
module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[1] (remote-exec): + sudo getent group nogroup
module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[1] (remote-exec): + sudo groupadd nogroup
module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[1] (remote-exec): + sudo getent group docker
module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[1] (remote-exec): docker:x:994:
module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[1] (remote-exec): + sudo touch /opt/dcos-prereqs.installed
module.dcos-master-instances.module.dcos-master-instances.null_resource.instance-prereq[1]: Creation complete after 3m39s (ID: 38012637605075667)

Error: Error applying plan:

1 error(s) occurred:

* module.dcos-install.module.dcos-bootstrap-install.null_resource.bootstrap: error executing "/tmp/terraform_1889024212.sh": Process exited with status 1
```

# Conclusion

At the end of all these changes, I got a working cluster in the end. Good work for providing this draft example! When you can please review the comments and changes to the template as well and we can ship. 
