### PR TITLE
Change Windows Terraform Verison

### DIFF
--- a/aws/windows-agent/main.tf
+++ b/aws/windows-agent/main.tf
@@ -53,7 +53,7 @@ dcos:
 
 module "windowsagent" {
   source  = "dcos-terraform/windows-instance/aws"
-  version = "~> 0.2.0"
+  version = "~> 0.0.3"
 
   cluster_name           = "${local.cluster_name}"
   hostname_format        = "%[3]s-winagent%[1]d-%[2]s"


### PR DESCRIPTION
According to [https://registry.terraform.io](https://registry.terraform.io/modules/dcos-terraform/windows-instance/aws/0.0.3) version `0.2.0` does not exist but `0.0.3`